### PR TITLE
Avoid any potential out-of-bounds indexing in neasyf_type

### DIFF
--- a/src/neasyf.f90
+++ b/src/neasyf.f90
@@ -280,43 +280,57 @@ contains
   function neasyf_type_rank1(variable) result(nf_type)
     integer(nf_kind) :: nf_type
     class(*), dimension(:), intent(in) :: variable
-    nf_type = neasyf_type(variable(1))
+    class(*), dimension(:), allocatable :: local
+    allocate(local(1), mold=variable)
+    nf_type = neasyf_type(local(1))
   end function neasyf_type_rank1
 
   function neasyf_type_rank2(variable) result(nf_type)
     integer(nf_kind) :: nf_type
     class(*), dimension(:, :), intent(in) :: variable
-    nf_type = neasyf_type(variable(1, 1))
+    class(*), dimension(:, :), allocatable :: local
+    allocate(local(1, 1), mold=variable)
+    nf_type = neasyf_type(local(1, 1))
   end function neasyf_type_rank2
 
   function neasyf_type_rank3(variable) result(nf_type)
     integer(nf_kind) :: nf_type
     class(*), dimension(:, :, :), intent(in) :: variable
-    nf_type = neasyf_type(variable(1, 1, 1))
+    class(*), dimension(:, :, :), allocatable :: local
+    allocate(local(1, 1, 1), mold=variable)
+    nf_type = neasyf_type(local(1, 1, 1))
   end function neasyf_type_rank3
 
   function neasyf_type_rank4(variable) result(nf_type)
     integer(nf_kind) :: nf_type
     class(*), dimension(:, :, :, :), intent(in) :: variable
-    nf_type = neasyf_type(variable(1, 1, 1, 1))
+    class(*), dimension(:, :, :, :), allocatable :: local
+    allocate(local(1, 1, 1, 1), mold=variable)
+    nf_type = neasyf_type(local(1, 1, 1, 1))
   end function neasyf_type_rank4
 
   function neasyf_type_rank5(variable) result(nf_type)
     integer(nf_kind) :: nf_type
     class(*), dimension(:, :, :, :, :), intent(in) :: variable
-    nf_type = neasyf_type(variable(1, 1, 1, 1, 1))
+    class(*), dimension(:, :, :, :, :), allocatable :: local
+    allocate(local(1, 1, 1, 1, 1), mold=variable)
+    nf_type = neasyf_type(local(1, 1, 1, 1, 1))
   end function neasyf_type_rank5
 
   function neasyf_type_rank6(variable) result(nf_type)
     integer(nf_kind) :: nf_type
     class(*), dimension(:, :, :, :, :, :), intent(in) :: variable
-    nf_type = neasyf_type(variable(1, 1, 1, 1, 1, 1))
+    class(*), dimension(:, :, :, :, :, :), allocatable :: local
+    allocate(local(1, 1, 1, 1, 1, 1), mold=variable)
+    nf_type = neasyf_type(local(1, 1, 1, 1, 1, 1))
   end function neasyf_type_rank6
 
   function neasyf_type_rank7(variable) result(nf_type)
     integer(nf_kind) :: nf_type
     class(*), dimension(:, :, :, :, :, :, :), intent(in) :: variable
-    nf_type = neasyf_type(variable(1, 1, 1, 1, 1, 1, 1))
+    class(*), dimension(:, :, :, :, :, :, :), allocatable :: local
+    allocate(local(1, 1, 1, 1, 1, 1, 1), mold=variable)
+    nf_type = neasyf_type(local(1, 1, 1, 1, 1, 1, 1))
   end function neasyf_type_rank7
 
 

--- a/src/neasyf.type.in.f90
+++ b/src/neasyf.type.in.f90
@@ -1,5 +1,7 @@
   function neasyf_type_rank{n}(variable) result(nf_type)
     integer(nf_kind) :: nf_type
     class(*), dimension({array(n)}), intent(in) :: variable
-    nf_type = neasyf_type(variable({slice(n)}))
+    class(*), dimension({array(n)}), allocatable :: local
+    allocate(local({slice(n)}), mold=variable)
+    nf_type = neasyf_type(local({slice(n)}))
   end function neasyf_type_rank{n}


### PR DESCRIPTION
Allocate a local variable with the same type as the input, but with exactly one element. This way we can be sure we can index it correctly to call the scalar version.

This shouldn't be a problem now that we explicitly disallow zero-sized dimensions, but it's nice to be safe in case the user created the dimensions some other way.