### PR TITLE
Bugfix/avoid hangs in parallel write of scalars

### DIFF
--- a/src/neasyf.f90
+++ b/src/neasyf.f90
@@ -27,7 +27,7 @@
 !>
 !> ! Writing string scalars will automatically create a corresponding
 !> ! dimension of the correct length as the trimmed string
-!> call neasfy_write(ncid, "scalar_text", "Some text as a variable")
+!> call neasyf_write(ncid, "scalar_text", "Some text as a variable")
 !>
 !> call neasyf_close(ncid)
 !> ```

--- a/src/neasyf.f90
+++ b/src/neasyf.f90
@@ -1121,6 +1121,7 @@ contains
     use netcdf, only : nf90_inq_varid, nf90_def_var, nf90_put_var, nf90_put_att, &
          NF90_ENOTVAR, nf90_def_dim, nf90_inq_dimid, nf90_var_par_access, &
          NF90_ENOPAR, NF90_NOERR
+    use netcdf, only : nf90_enddef
     use netcdf, only : NF90_EDIMMETA
     !> Name of the variable
     character(len=*), intent(in) :: name
@@ -1216,6 +1217,8 @@ contains
       varid = var_id
     end if
 
+    status = nf90_enddef(parent_id)
+    call neasyf_error(status, var=name, varid=var_id)
     if (present(count)) then
       if (product(count) == 0) return
     end if
@@ -2327,6 +2330,7 @@ contains
     use netcdf, only : nf90_inq_varid, nf90_def_var, nf90_put_var, nf90_put_att, &
          NF90_ENOTVAR, nf90_def_dim, nf90_inq_dimid, nf90_var_par_access, &
          NF90_ENOPAR, NF90_NOERR
+    use netcdf, only : nf90_enddef
     use netcdf, only : NF90_EDIMMETA
     !> Name of the variable
     character(len=*), intent(in) :: name
@@ -2422,6 +2426,8 @@ contains
       varid = var_id
     end if
 
+    status = nf90_enddef(parent_id)
+    call neasyf_error(status, var=name, varid=var_id)
     if (present(count)) then
       if (product(count) == 0) return
     end if
@@ -3533,6 +3539,7 @@ contains
     use netcdf, only : nf90_inq_varid, nf90_def_var, nf90_put_var, nf90_put_att, &
          NF90_ENOTVAR, nf90_def_dim, nf90_inq_dimid, nf90_var_par_access, &
          NF90_ENOPAR, NF90_NOERR
+    use netcdf, only : nf90_enddef
     use netcdf, only : NF90_EDIMMETA
     !> Name of the variable
     character(len=*), intent(in) :: name
@@ -3628,6 +3635,8 @@ contains
       varid = var_id
     end if
 
+    status = nf90_enddef(parent_id)
+    call neasyf_error(status, var=name, varid=var_id)
     if (present(count)) then
       if (product(count) == 0) return
     end if
@@ -4739,6 +4748,7 @@ contains
     use netcdf, only : nf90_inq_varid, nf90_def_var, nf90_put_var, nf90_put_att, &
          NF90_ENOTVAR, nf90_def_dim, nf90_inq_dimid, nf90_var_par_access, &
          NF90_ENOPAR, NF90_NOERR
+    use netcdf, only : nf90_enddef
     use netcdf, only : NF90_EDIMMETA
     !> Name of the variable
     character(len=*), intent(in) :: name
@@ -4834,6 +4844,8 @@ contains
       varid = var_id
     end if
 
+    status = nf90_enddef(parent_id)
+    call neasyf_error(status, var=name, varid=var_id)
     if (present(count)) then
       if (product(count) == 0) return
     end if
@@ -5945,6 +5957,7 @@ contains
     use netcdf, only : nf90_inq_varid, nf90_def_var, nf90_put_var, nf90_put_att, &
          NF90_ENOTVAR, nf90_def_dim, nf90_inq_dimid, nf90_var_par_access, &
          NF90_ENOPAR, NF90_NOERR
+    use netcdf, only : nf90_enddef
     use netcdf, only : NF90_EDIMMETA
     !> Name of the variable
     character(len=*), intent(in) :: name
@@ -6040,6 +6053,8 @@ contains
       varid = var_id
     end if
 
+    status = nf90_enddef(parent_id)
+    call neasyf_error(status, var=name, varid=var_id)
     if (present(count)) then
       if (product(count) == 0) return
     end if
@@ -7151,6 +7166,7 @@ contains
     use netcdf, only : nf90_inq_varid, nf90_def_var, nf90_put_var, nf90_put_att, &
          NF90_ENOTVAR, nf90_def_dim, nf90_inq_dimid, nf90_var_par_access, &
          NF90_ENOPAR, NF90_NOERR
+    use netcdf, only : nf90_enddef
     !> Name of the variable
     character(len=*), intent(in) :: name
     !> NetCDF ID of the parent group/file
@@ -7230,6 +7246,8 @@ contains
       varid = var_id
     end if
 
+    status = nf90_enddef(parent_id)
+    call neasyf_error(status, var=name, varid=var_id)
     if (present(count)) then
       if (product(count) == 0) return
     end if

--- a/src/neasyf.f90
+++ b/src/neasyf.f90
@@ -1121,7 +1121,7 @@ contains
     use netcdf, only : nf90_inq_varid, nf90_def_var, nf90_put_var, nf90_put_att, &
          NF90_ENOTVAR, nf90_def_dim, nf90_inq_dimid, nf90_var_par_access, &
          NF90_ENOPAR, NF90_NOERR
-    use netcdf, only : nf90_enddef
+    use netcdf, only : nf90_enddef, NF90_ENOTINDEFINE
     use netcdf, only : NF90_EDIMMETA
     !> Name of the variable
     character(len=*), intent(in) :: name
@@ -1218,7 +1218,9 @@ contains
     end if
 
     status = nf90_enddef(parent_id)
-    call neasyf_error(status, var=name, varid=var_id)
+    if (.not. (status == NF90_NOERR .or. status == NF90_ENOTINDEFINE)) then
+       call neasyf_error(status, ncid=parent_id, var=name, varid=var_id)
+    end if
     if (present(count)) then
       if (product(count) == 0) return
     end if
@@ -2330,7 +2332,7 @@ contains
     use netcdf, only : nf90_inq_varid, nf90_def_var, nf90_put_var, nf90_put_att, &
          NF90_ENOTVAR, nf90_def_dim, nf90_inq_dimid, nf90_var_par_access, &
          NF90_ENOPAR, NF90_NOERR
-    use netcdf, only : nf90_enddef
+    use netcdf, only : nf90_enddef, NF90_ENOTINDEFINE
     use netcdf, only : NF90_EDIMMETA
     !> Name of the variable
     character(len=*), intent(in) :: name
@@ -2427,7 +2429,9 @@ contains
     end if
 
     status = nf90_enddef(parent_id)
-    call neasyf_error(status, var=name, varid=var_id)
+    if (.not. (status == NF90_NOERR .or. status == NF90_ENOTINDEFINE)) then
+       call neasyf_error(status, ncid=parent_id, var=name, varid=var_id)
+    end if
     if (present(count)) then
       if (product(count) == 0) return
     end if
@@ -3539,7 +3543,7 @@ contains
     use netcdf, only : nf90_inq_varid, nf90_def_var, nf90_put_var, nf90_put_att, &
          NF90_ENOTVAR, nf90_def_dim, nf90_inq_dimid, nf90_var_par_access, &
          NF90_ENOPAR, NF90_NOERR
-    use netcdf, only : nf90_enddef
+    use netcdf, only : nf90_enddef, NF90_ENOTINDEFINE
     use netcdf, only : NF90_EDIMMETA
     !> Name of the variable
     character(len=*), intent(in) :: name
@@ -3636,7 +3640,9 @@ contains
     end if
 
     status = nf90_enddef(parent_id)
-    call neasyf_error(status, var=name, varid=var_id)
+    if (.not. (status == NF90_NOERR .or. status == NF90_ENOTINDEFINE)) then
+       call neasyf_error(status, ncid=parent_id, var=name, varid=var_id)
+    end if
     if (present(count)) then
       if (product(count) == 0) return
     end if
@@ -4748,7 +4754,7 @@ contains
     use netcdf, only : nf90_inq_varid, nf90_def_var, nf90_put_var, nf90_put_att, &
          NF90_ENOTVAR, nf90_def_dim, nf90_inq_dimid, nf90_var_par_access, &
          NF90_ENOPAR, NF90_NOERR
-    use netcdf, only : nf90_enddef
+    use netcdf, only : nf90_enddef, NF90_ENOTINDEFINE
     use netcdf, only : NF90_EDIMMETA
     !> Name of the variable
     character(len=*), intent(in) :: name
@@ -4845,7 +4851,9 @@ contains
     end if
 
     status = nf90_enddef(parent_id)
-    call neasyf_error(status, var=name, varid=var_id)
+    if (.not. (status == NF90_NOERR .or. status == NF90_ENOTINDEFINE)) then
+       call neasyf_error(status, ncid=parent_id, var=name, varid=var_id)
+    end if
     if (present(count)) then
       if (product(count) == 0) return
     end if
@@ -5957,7 +5965,7 @@ contains
     use netcdf, only : nf90_inq_varid, nf90_def_var, nf90_put_var, nf90_put_att, &
          NF90_ENOTVAR, nf90_def_dim, nf90_inq_dimid, nf90_var_par_access, &
          NF90_ENOPAR, NF90_NOERR
-    use netcdf, only : nf90_enddef
+    use netcdf, only : nf90_enddef, NF90_ENOTINDEFINE
     use netcdf, only : NF90_EDIMMETA
     !> Name of the variable
     character(len=*), intent(in) :: name
@@ -6054,7 +6062,9 @@ contains
     end if
 
     status = nf90_enddef(parent_id)
-    call neasyf_error(status, var=name, varid=var_id)
+    if (.not. (status == NF90_NOERR .or. status == NF90_ENOTINDEFINE)) then
+       call neasyf_error(status, ncid=parent_id, var=name, varid=var_id)
+    end if
     if (present(count)) then
       if (product(count) == 0) return
     end if
@@ -7166,7 +7176,7 @@ contains
     use netcdf, only : nf90_inq_varid, nf90_def_var, nf90_put_var, nf90_put_att, &
          NF90_ENOTVAR, nf90_def_dim, nf90_inq_dimid, nf90_var_par_access, &
          NF90_ENOPAR, NF90_NOERR
-    use netcdf, only : nf90_enddef
+    use netcdf, only : nf90_enddef, NF90_ENOTINDEFINE
     !> Name of the variable
     character(len=*), intent(in) :: name
     !> NetCDF ID of the parent group/file
@@ -7247,7 +7257,9 @@ contains
     end if
 
     status = nf90_enddef(parent_id)
-    call neasyf_error(status, var=name, varid=var_id)
+    if (.not. (status == NF90_NOERR .or. status == NF90_ENOTINDEFINE)) then
+       call neasyf_error(status, ncid=parent_id, var=name, varid=var_id)
+    end if
     if (present(count)) then
       if (product(count) == 0) return
     end if

--- a/src/neasyf.in.f90
+++ b/src/neasyf.in.f90
@@ -27,7 +27,7 @@
 !>
 !> ! Writing string scalars will automatically create a corresponding
 !> ! dimension of the correct length as the trimmed string
-!> call neasfy_write(ncid, "scalar_text", "Some text as a variable")
+!> call neasyf_write(ncid, "scalar_text", "Some text as a variable")
 !>
 !> call neasyf_close(ncid)
 !> ```

--- a/src/neasyf.in.f90
+++ b/src/neasyf.in.f90
@@ -546,7 +546,7 @@ contains
          NF90_ENOTVAR, nf90_def_dim, nf90_inq_dimid, nf90_var_par_access, &
          NF90_ENOPAR, NF90_NOERR
 #:if (RANK == 0)
-    use netcdf, only : nf90_enddef
+    use netcdf, only : nf90_enddef, NF90_ENOTINDEFINE
 #:endif
 #:if not (RANK == 0 and TYPE_NAME.startswith("character"))
     use netcdf, only : NF90_EDIMMETA
@@ -681,7 +681,9 @@ contains
 
 #:if RANK == 0
     status = nf90_enddef(parent_id)
-    call neasyf_error(status, var=name, varid=var_id)
+    if (.not. (status == NF90_NOERR .or. status == NF90_ENOTINDEFINE)) then
+       call neasyf_error(status, ncid=parent_id, var=name, varid=var_id)
+    end if
     if (present(count)) then
       if (product(count) == 0) return
     end if

--- a/src/neasyf.in.f90
+++ b/src/neasyf.in.f90
@@ -545,6 +545,9 @@ contains
     use netcdf, only : nf90_inq_varid, nf90_def_var, nf90_put_var, nf90_put_att, &
          NF90_ENOTVAR, nf90_def_dim, nf90_inq_dimid, nf90_var_par_access, &
          NF90_ENOPAR, NF90_NOERR
+#:if (RANK == 0)
+    use netcdf, only : nf90_enddef
+#:endif
 #:if not (RANK == 0 and TYPE_NAME.startswith("character"))
     use netcdf, only : NF90_EDIMMETA
 #:endif
@@ -677,6 +680,8 @@ contains
     end if
 
 #:if RANK == 0
+    status = nf90_enddef(parent_id)
+    call neasyf_error(status, var=name, varid=var_id)
     if (present(count)) then
       if (product(count) == 0) return
     end if


### PR DESCRIPTION
Try to avoid potential hanging when writing scalars to parallel files with at least one processor passing `count = 0` by ensuring the file is not in define mode before potential early exit.