### PR TITLE
Allow one to query the size of an existing dimension

### DIFF
--- a/src/neasyf.f90
+++ b/src/neasyf.f90
@@ -466,7 +466,7 @@ contains
   !> through `dimid` and `varid` respectively.
   subroutine neasyf_dim_index(parent_id, name, dim_size, dimid, varid, units, long_name, unlimited)
     use netcdf, only : nf90_inq_dimid, nf90_inq_varid, nf90_def_var, nf90_def_dim, nf90_put_var, nf90_put_att, &
-         NF90_NOERR, NF90_EBADDIM, NF90_UNLIMITED
+         NF90_NOERR, NF90_EBADDIM, NF90_UNLIMITED, nf90_inquire_dimension
     !> Name of the variable
     character(len=*), intent(in) :: name
     !> NetCDF ID of the parent group/file

--- a/src/neasyf.f90
+++ b/src/neasyf.f90
@@ -472,7 +472,7 @@ contains
     !> NetCDF ID of the parent group/file
     integer, intent(in) :: parent_id
     !> Size of the dimension if values isn't specified
-    integer, optional, intent(in) :: dim_size
+    integer, optional, intent(in out) :: dim_size
     !> NetCDF ID of the dimension
     integer, optional, intent(out) :: dimid
     !> NetCDF ID of the corresponding variable
@@ -494,6 +494,10 @@ contains
     if (status == NF90_NOERR) then
       if (present(dimid)) then
         dimid = dim_id
+      end if
+
+      if (present(dim_size)) then
+         call neasyf_error(nf90_inquire_dimension(parent_id, dim_id, len = dim_size))
       end if
 
       if (present(varid)) then

--- a/src/neasyf.in.f90
+++ b/src/neasyf.in.f90
@@ -338,7 +338,7 @@ contains
   !> through `dimid` and `varid` respectively.
   subroutine neasyf_dim_index(parent_id, name, dim_size, dimid, varid, units, long_name, unlimited)
     use netcdf, only : nf90_inq_dimid, nf90_inq_varid, nf90_def_var, nf90_def_dim, nf90_put_var, nf90_put_att, &
-         NF90_NOERR, NF90_EBADDIM, NF90_UNLIMITED
+         NF90_NOERR, NF90_EBADDIM, NF90_UNLIMITED, nf90_inquire_dimension
     !> Name of the variable
     character(len=*), intent(in) :: name
     !> NetCDF ID of the parent group/file

--- a/src/neasyf.in.f90
+++ b/src/neasyf.in.f90
@@ -344,7 +344,7 @@ contains
     !> NetCDF ID of the parent group/file
     integer, intent(in) :: parent_id
     !> Size of the dimension if values isn't specified
-    integer, optional, intent(in) :: dim_size
+    integer, optional, intent(in out) :: dim_size
     !> NetCDF ID of the dimension
     integer, optional, intent(out) :: dimid
     !> NetCDF ID of the corresponding variable
@@ -366,6 +366,10 @@ contains
     if (status == NF90_NOERR) then
       if (present(dimid)) then
         dimid = dim_id
+      end if
+
+      if (present(dim_size)) then
+         call neasyf_error(nf90_inquire_dimension(parent_id, dim_id, len = dim_size))
       end if
 
       if (present(varid)) then


### PR DESCRIPTION
Allows one to query the size on an existing dimension. For symmetry we _could_ perhaps also allow the `values` based overload to return the actual values (as this doesn't have a `dim_size` argument) or we could add a `dim_size` argument to these overloads (requiring a check that dim_size and values aren't set, or at least if both are set then are consistent).